### PR TITLE
Added Jog State and PID movement for Intake

### DIFF
--- a/src/main/java/org/ironriders/intake/IntakeCommands.java
+++ b/src/main/java/org/ironriders/intake/IntakeCommands.java
@@ -1,6 +1,7 @@
 package org.ironriders.intake;
 
 import static org.ironriders.intake.IntakeConstants.DISCHARGE_TIMEOUT;
+import static org.ironriders.intake.IntakeConstants.L4JOGDISTANCE;
 
 import org.ironriders.intake.IntakeConstants.IntakeState;
 
@@ -20,6 +21,7 @@ public class IntakeCommands {
     intake.publish("Intake Score", set(IntakeState.SCORE));
     intake.publish("Intake Eject", set(IntakeState.EJECT));
     intake.publish("Intake Stop", set(IntakeState.STOP));
+    intake.publish("Intake Jog", set(IntakeState.JOG));
   }
 
   public Command set(IntakeConstants.IntakeState state) {
@@ -35,6 +37,9 @@ public class IntakeCommands {
         return command
             .withTimeout(DISCHARGE_TIMEOUT)
             .finallyDo(() -> intake.set(IntakeState.STOP));
+      case JOG:
+        intake.setGoalAngle(L4JOGDISTANCE);
+        return command.finallyDo(() -> intake.set(IntakeState.STOP));
       default:
         return command.finallyDo(() -> intake.set(IntakeState.STOP));
     }

--- a/src/main/java/org/ironriders/intake/IntakeConstants.java
+++ b/src/main/java/org/ironriders/intake/IntakeConstants.java
@@ -19,6 +19,18 @@ public class IntakeConstants {
   public static final double RIGHT_SPEED_MUL = 1;
   public static final double ROLLER_SPEED_MUL = 1;
 
+  public static final double VERTICAL_ENCODER_SCALE = 1; //TODO I just pinged design
+
+  public static final double PROPORTIONAL = 0.01;
+  public static final double INTEGRAL = 0.00;
+  public static final double DERIVATIVE = 0.00;
+  public static final double TOLERANCE = 1.0;
+
+  public static final double MAX_VEL = 30;
+  public static final double MAX_ACC = 30;
+
+  public static final double L4JOGDISTANCE = 20; //IN degrees 
+
   // TODO Tune These
   public static final int INTAKE_STATOR_CURRENT = 30; // Stator Current Torque and Acceleration
   public static final int INTAKE_SUPPLY_CURRENT = 40; // Supply Current Speed + (a little Torque). If Supply
@@ -38,7 +50,8 @@ public class IntakeConstants {
     GRAB(.25),
     SCORE(.30),
     EJECT(-.10),
-    STOP(0.00);
+    STOP(0.00),
+    JOG(0.00);
 
     public final double speed;
 

--- a/src/main/java/org/ironriders/intake/IntakeSubsystem.java
+++ b/src/main/java/org/ironriders/intake/IntakeSubsystem.java
@@ -15,7 +15,9 @@ import static org.ironriders.intake.IntakeConstants.INTAKE_SUPPLY_CURRENT_LOWER_
 import static org.ironriders.intake.IntakeConstants.LEFT_SPEED_MUL;
 import static org.ironriders.intake.IntakeConstants.RIGHT_SPEED_MUL;
 import static org.ironriders.intake.IntakeConstants.ROLLER_SPEED_MUL;
+import static org.ironriders.intake.IntakeConstants.VERTICAL_ENCODER_SCALE;
 
+import org.ironmaple.simulation.IntakeSimulation.IntakeSide;
 import org.ironriders.intake.IntakeConstants.IntakeState;
 import org.ironriders.lib.IronSubsystem;
 
@@ -24,12 +26,25 @@ import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.hardware.TalonFX;
 
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.DigitalInput;
 
 public class IntakeSubsystem extends IronSubsystem {
 
   private final IntakeCommands commands;
+
+  private PIDController pidControler;
+  private TrapezoidProfile.State stopped;
+
+  private TrapezoidProfile.State goalSetpoint = new TrapezoidProfile.State(); // Acts as a final setpoint
+  private TrapezoidProfile.State periodicSetpoint = new TrapezoidProfile.State(); //Acts a intermidete setpoint
+  final TrapezoidProfile movementProfile = new TrapezoidProfile(
+            new Constraints(IntakeConstants.MAX_VEL, IntakeConstants.MAX_ACC));
+
+  private IntakeState intakeState = IntakeState.STOP;
 
   private final TalonFX rightIntake = new TalonFX(INTAKE_MOTOR_RIGHT);
   private final TalonFX leftIntake = new TalonFX(INTAKE_MOTOR_LEFT);
@@ -65,6 +80,13 @@ public class IntakeSubsystem extends IronSubsystem {
     rollerIntake.getConfigurator().apply(mainConfig);
     rollerIntake.getConfigurator().apply(new MotorOutputConfigs().withInverted(INTAKE_MOTOR_ROLLER_INVERSION));
 
+
+    pidControler = new PIDController(
+                IntakeConstants.PROPORTIONAL,
+                IntakeConstants.INTEGRAL,
+                IntakeConstants.DERIVATIVE);
+        pidControler.setTolerance(IntakeConstants.TOLERANCE);
+
     commands = new IntakeCommands(this);
   }
 
@@ -80,14 +102,29 @@ public class IntakeSubsystem extends IronSubsystem {
     average = (leftIntake.getTorqueCurrent().getValueAsDouble() + rightIntake.getTorqueCurrent().getValueAsDouble())
         / 2f;
     publish("Current average", average);
+
+
+    periodicSetpoint = movementProfile.calculate(
+                0.02,
+                periodicSetpoint,
+                goalSetpoint);
+
+        double speed = pidControler.calculate(getCurrentAngle(), periodicSetpoint.position);
+        if(intakeState.equals(IntakeState.JOG)){
+          leftIntake.set(speed);
+          rightIntake.set(speed);
+        }
   }
 
   public void set(IntakeState state) {
+    intakeState = state;
     publish("Intake State", state.toString());
     // logMessage("goes to " + state.toString());
-    leftIntake.set(state.speed * outputDifferential(state, LEFT_SPEED_MUL));
-    rightIntake.set(state.speed * outputDifferential(state, RIGHT_SPEED_MUL));
-    rollerIntake.set(state.speed * outputDifferential(state, ROLLER_SPEED_MUL));
+      if(state.toString().equals(IntakeState.JOG.toString())){
+        leftIntake.set(state.speed * outputDifferential(state, LEFT_SPEED_MUL));
+        rightIntake.set(state.speed * outputDifferential(state, RIGHT_SPEED_MUL));
+        rollerIntake.set(state.speed * outputDifferential(state, ROLLER_SPEED_MUL));
+      }
   }
 
   public double outputDifferential(IntakeState state, double controlSpeedMultipler) {
@@ -98,12 +135,20 @@ public class IntakeSubsystem extends IronSubsystem {
   }
 
   public boolean hasHighCurrent() {
-    return false;
+    return false; 
     // return average > 12 && !beamBreak.get(); disabled because beam break made it hard to intake
   }
 
   public boolean beamBreakTriggered() {
     return !beamBreak.get();
+  }
+
+  public double getCurrentAngle(){
+    return rightIntake.getPosition().getValue().in(Units.Degrees) * VERTICAL_ENCODER_SCALE;
+  }
+
+  public void setGoalAngle(double angleOffsetFromCurrent){ // The intake could be in any position and we just want to set it to a value 
+    goalSetpoint = new TrapezoidProfile.State(getCurrentAngle() +angleOffsetFromCurrent, 0);
   }
 
   public IntakeCommands getCommands() {


### PR DESCRIPTION
Added Jog State and PID to move the coral inside the intake. 

PID values and set point, Acceleration, and Velocity all still need to be tested;
Gear ratio for Encoder scale still needs to be set, but I just asked design. 

PID had to be added too periodic to update the speed values because the old way of setting the seed of the motors only did it once when the command was run. This means that the motor positions are updated in periodic as well. Currently, it just turns the PID on if the beam break is triggered so we get a consistent start point, via suggestion from Jim.